### PR TITLE
Using the right type of MMapPageGranularity for windows

### DIFF
--- a/store/mmap_windows.go
+++ b/store/mmap_windows.go
@@ -19,4 +19,4 @@ package store
 //
 // See: https://social.msdn.microsoft.com/Forums/vstudio/en-US/972f36a4-26c9-466b-861a-5f40fa4cf4e7/about-the-dwallocationgranularity?forum=vclanguage
 //
-var MMapPageGranularity = 65536 // 64kiB.
+var MMapPageGranularity = int64(65536) // 64kiB.


### PR DESCRIPTION
Fix for the  compilation err in windows:


>  ##[error]C:\Users\runneradmin\go\pkg\mod\github.com\couchbase\rhmap@v0.0.0-20200429065529-587a5df20e06\store\mmap.go:124:28: cannot use MMapPageGranularity (type int) as type int64 in argument to pageOffset